### PR TITLE
[MAT-7230] refactor spaceless tag usage

### DIFF
--- a/html/themes/custom/madie/components/_patterns/01-atoms/05-forms/_select-element.twig
+++ b/html/themes/custom/madie/components/_patterns/01-atoms/05-forms/_select-element.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_select()
  */
 #}
-{% spaceless %}
+{% apply spaceless %}
   <div class="form-item__dropdown">
     <select{{ attributes.addClass('form-item__select') }}>
       {% for option in options %}
@@ -26,4 +26,4 @@
       {% endfor %}
     </select>
   </div>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
`spaceless` tag is deprecated, use the `apply` tag instead https://twig.symfony.com/doc/3.x/filters/spaceless.html